### PR TITLE
Add some bundle instructions to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,5 +19,9 @@ bundle install
 bundle exec ruby app.rb
 ```
 
-You will need to go through some more setup steps once you get the application
-itself running, but it will walk you through it!
+You will need to go through some more setup steps (e.g. setting up a Dropbox
+app) once you get the application itself running, but it will walk you through
+it!
+
+Once you have everything set up, you can access the Mosaic server locally at
+`http://localhost:4567`.

--- a/README.md
+++ b/README.md
@@ -14,8 +14,9 @@ npm install
 webpack app/js/main.jsx -p
 wget http://sketchtool.bohemiancoding.com/sketchtool-latest.zip
 unzip sketchtool-latest.zip -d vendor
+bundle install
 
-ruby app.rb
+bundle exec ruby app.rb
 ```
 
 You will need to go through some more setup steps once you get the application


### PR DESCRIPTION
In getting Mosaic set up for the first time on my laptop, I ran into a
couple of steps that differed from the readme. bundle install and bundle
exec should smooth things out for the next person who wants to attempt
getting this set up.
