### PR TITLE
Render <Waypoint> only when needed

### DIFF
--- a/app/components/search_result_slice/index.jsx
+++ b/app/components/search_result_slice/index.jsx
@@ -18,11 +18,11 @@ const SearchResultSlice = React.createClass({
 
     return (
       <div className="result-slice col-xs-4">
-        <Waypoint onEnter={this.showImages} threshold={0.2} />
         <a href={slice.path} target='_new'>
           <h3>{slice.layer}</h3>
-          {this.state.showImages &&
-            <img className='result-slice-image' src={thumb_url} />}
+          {this.state.showImages ?
+            <img className='result-slice-image' src={thumb_url} /> :
+            <Waypoint onEnter={this.showImages} threshold={0.2} />}
         </a>
       </div>
     );


### PR DESCRIPTION
We only need these waypoints before images have loaded the first time.
We can just remove them from the page when they are no longer needed,
which will remove event listeners, likely improving app performance.
