### PR TITLE
Remove jquery dependency from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "mosaic",
   "repository": "https://github.com/tdooner/mosaic",
   "dependencies": {
-    "jquery": "^2.1.4",
     "jsx-loader": "^0.13.2",
     "moment": "^2.10.2",
     "mousetrap": "^1.5.2",


### PR DESCRIPTION
Mosaic no longer uses jquery, so we can remove it from the list of
dependencies.
