### PR TITLE
Open links in "_blank" target

### DIFF
--- a/app/components/search_result_file/index.jsx
+++ b/app/components/search_result_file/index.jsx
@@ -21,7 +21,7 @@ const SearchResultFile = React.createClass({
           {' ' + moment(result.last_modified).fromNow()}
           {' \u00b7 '}
           {(result.tags.length > 0) && result.tags.join(',')}
-          <a target='_new' href={`/download/${result.file_id}`}>
+          <a target='_blank' href={`/download/${result.file_id}`}>
             Download from Dropbox
           </a>
         </div>

--- a/app/components/search_result_slice/index.jsx
+++ b/app/components/search_result_slice/index.jsx
@@ -19,7 +19,7 @@ const SearchResultSlice = React.createClass({
     return (
       <div className="result-slice col-xs-4">
         <Waypoint onEnter={this.showImages} threshold={0.2} />
-        <a href={slice.path} target='_new'>
+        <a href={slice.path} target='_blank'>
           <h3>{slice.layer}</h3>
           {this.state.showImages &&
             <img className='result-slice-image' src={thumb_url} />}


### PR DESCRIPTION
I noticed that links from search results were opened in an existing
tab/window the second time you clicked a link. I think the old "_new"
link target was a mistake, and the intention was actually "_blank".

We might also consider not using a target at all, and let the user
decide what behavior he/she wants. Some people argue that _blank is bad:

https://css-tricks.com/use-target_blank/
